### PR TITLE
Clamp grid coordinates to boundaries

### DIFF
--- a/levels/colors_level.py
+++ b/levels/colors_level.py
@@ -109,8 +109,8 @@ class ColorsLevel:
         for i, dot in enumerate(self.dots):
             if not dot["alive"]:
                 continue
-            grid_x = int(dot["x"] // self.grid_size)
-            grid_y = int(dot["y"] // self.grid_size)
+            grid_x = min(max(int(dot["x"] // self.grid_size), 0), self.grid_cols - 1)
+            grid_y = min(max(int(dot["y"] // self.grid_size), 0), self.grid_rows - 1)
             grid[(grid_x, grid_y)].append(i)
         return grid
         


### PR DESCRIPTION
Clamp spatial grid coordinates to prevent out-of-bounds keys and excessive memory usage.